### PR TITLE
Added account id to bucket name to ensure uniqueness

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -66,7 +66,7 @@ resource "aws_s3_bucket_policy" "audit_log" {
 
 resource "aws_s3_bucket" "access_log" {
   count  = var.s3_enabled ? 1 : 0
-  bucket = "${var.resource_name_prefix}-access-logs"
+  bucket = "${var.resource_name_prefix}-${var.aws_account_id}-access-logs"
   force_destroy = true
   tags          = var.tags
 }
@@ -100,7 +100,7 @@ resource "aws_s3_bucket_public_access_block" "access_log" {
 
 resource "aws_s3_bucket" "audit" {
   count  = var.s3_enabled ? 1 : 0
-  bucket = "${var.resource_name_prefix}-audit-logs"
+  bucket = "${var.resource_name_prefix}-${var.aws_account_id}-audit-logs"
   force_destroy = true
   tags = var.tags
 }


### PR DESCRIPTION
Using the default resource prefix of aws-cis yields a bucket name of aws-cis-audit-logs which appears to already exist.

Insert the account id into the bucket name to yield a unique name.

Original error, ideally the AWS API would give a better response for an existing bucket but I see the security issue there:
`Error: creating Amazon S3 (Simple Storage) Bucket (aws-cis-audit-logs): AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-central-1'
│ 	status code: 400, request id: AENNHNACK4Z82XND, host id: +5V93mvxTjXkRzWtI34PHJj5alivNUxyzFloJMKQAl2CCmDFdVwkP1M4qYDYJIGl3q3c2bhB8tw=
│ 
│   with aws_s3_bucket.audit[0],
│   on s3.tf line 101, in resource "aws_s3_bucket" "audit":
│  101: resource "aws_s3_bucket" "audit" {
│ 
╵
`